### PR TITLE
feat: 마크다운 렌더링 기능 개선 - 괄호 포함 굵은 글씨 파싱 및 코드 블록 복사 버튼 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
+        "@rehype-pretty/transformers": "^0.13.2",
         "@remixicon/react": "^4.6.0",
         "@tailwindcss/typography": "^0.5.16",
         "classnames": "^2.5.1",
@@ -1190,6 +1191,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/@rehype-pretty/transformers": {
+      "version": "0.13.2",
+      "resolved": "https://registry.npmjs.org/@rehype-pretty/transformers/-/transformers-0.13.2.tgz",
+      "integrity": "sha512-p2ciQSwqy5Ip8aNUa9q6rdS/hJZXrxHYYfDVOHvKOsBu3t9HDmQ65YX6r9Qbl19vi160OAxmGF7MIoCRDJrRhg==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@remixicon/react": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "generate-search-index": "tsx src/scripts/generate-search-index.ts"
   },
   "dependencies": {
+    "@rehype-pretty/transformers": "^0.13.2",
     "@remixicon/react": "^4.6.0",
     "@tailwindcss/typography": "^0.5.16",
     "classnames": "^2.5.1",

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -46,3 +46,8 @@ body {
 html {
   @apply scroll-smooth text-base text-gray-800;
 }
+
+/* 코드 블록 복사 버튼 스타일 */
+button.rehype-pretty-copy {
+  @apply cursor-pointer;
+}

--- a/src/lib/markdownToHtml.ts
+++ b/src/lib/markdownToHtml.ts
@@ -1,3 +1,4 @@
+import { transformerCopyButton } from '@rehype-pretty/transformers';
 import rehypePrettyCode, { type Options } from 'rehype-pretty-code';
 import rehypeStringify from 'rehype-stringify';
 import remarkGfm from 'remark-gfm';
@@ -90,6 +91,12 @@ const options: Options = {
     block: 'javascript',
     inline: 'plaintext',
   },
+  transformers: [
+    transformerCopyButton({
+      visibility: 'hover',
+      feedbackDuration: 2000,
+    }),
+  ],
 };
 
 export type TocItem = {

--- a/src/lib/markdownToHtml.ts
+++ b/src/lib/markdownToHtml.ts
@@ -6,6 +6,62 @@ import remarkRehype from 'remark-rehype';
 import { unified } from 'unified';
 import { visit } from 'unist-util-visit';
 
+// 커스텀 플러그인: 괄호가 포함된 굵은 글씨 처리
+function remarkBoldWithParentheses() {
+  return (tree: any) => {
+    visit(tree, 'text', (node: any, index: number | undefined, parent: any) => {
+      if (!node.value || index === undefined) return;
+
+      // **text(inside)** 패턴을 찾아서 처리
+      const boldWithParensRegex = /\*\*([^*]+\([^)]*\)[^*]*)\*\*/g;
+      const matches = [...node.value.matchAll(boldWithParensRegex)];
+
+      if (matches.length > 0) {
+        const children: any[] = [];
+        let lastIndex = 0;
+
+        matches.forEach((match) => {
+          const fullMatch = match[0];
+          const content = match[1];
+          const matchIndex = match.index!;
+
+          // 매치 이전의 텍스트 추가
+          if (matchIndex > lastIndex) {
+            children.push({
+              type: 'text',
+              value: node.value.slice(lastIndex, matchIndex),
+            });
+          }
+
+          // 굵은 글씨 노드 추가
+          children.push({
+            type: 'strong',
+            children: [
+              {
+                type: 'text',
+                value: content,
+              },
+            ],
+          });
+
+          lastIndex = matchIndex + fullMatch.length;
+        });
+
+        // 마지막 매치 이후의 텍스트 추가
+        if (lastIndex < node.value.length) {
+          children.push({
+            type: 'text',
+            value: node.value.slice(lastIndex),
+          });
+        }
+
+        // 부모 노드의 children 배열을 업데이트
+        parent.children.splice(index, 1, ...children);
+      }
+    });
+  };
+}
+
 const options: Options = {
   // 라이트/다크 모드 모두 지정
   theme: {
@@ -74,7 +130,7 @@ export default async function markdownToHtml(markdown: string) {
         };
       });
     })
-    .use(remarkParse)
+    .use(remarkBoldWithParentheses)
     .use(remarkRehype)
     .use(rehypePrettyCode, options)
     .use(remarkGfm)


### PR DESCRIPTION
## **Description**

마크다운 렌더링 기능을 개선하여 사용자 경험을 향상시켰습니다.

- 괄호가 포함된 굵은 글씨(`**text(inside)**`) 파싱 문제 해결
- 코드 블록에 복사 버튼 기능 추가로 코드 공유 편의성 증대

## **Changes**
* 괄호가 포함된 굵은 글씨 파싱 문제 해결
  - `remarkBoldWithParentheses` 커스텀 플러그인 추가
  - `**text(inside)**` 패턴을 올바른 strong 요소로 변환
* 코드 블록 복사 버튼 기능 추가
  - `@rehype-pretty/transformers` 패키지 설치
  - `transformerCopyButton` 플러그인 적용
  - hover 시 복사 버튼 표시, 클릭 시 클립보드 복사
* 복사 버튼 UX 개선
  - `cursor: pointer` 스타일 추가로 클릭 가능함을 명시

## **Screenshots**
<img width="473" height="96" alt="스크린샷 2025-10-04 19 19 34" src="https://github.com/user-attachments/assets/740bdc31-f1c6-42aa-8e11-a7764f2a3b6f" />
<img width="516" height="242" alt="스크린샷 2025-10-04 19 19 44" src="https://github.com/user-attachments/assets/7ff4f68c-b953-4235-a3e4-c2a31373223d" />

